### PR TITLE
[DEV-11054] Fix - "Preview" banner for confidential stories

### DIFF
--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -1,6 +1,11 @@
 import { useAnalyticsContext } from '@prezly/analytics-nextjs';
-import type { Notification } from '@prezly/sdk';
-import { PageSeo, useNewsroom, useNewsroomContext } from '@prezly/theme-kit-nextjs';
+import { Notification, Story } from '@prezly/sdk';
+import {
+    PageSeo,
+    useCurrentStory,
+    useNewsroom,
+    useNewsroomContext,
+} from '@prezly/theme-kit-nextjs';
 import dynamic from 'next/dynamic';
 import { Router, useRouter } from 'next/router';
 import type { PropsWithChildren } from 'react';
@@ -30,28 +35,35 @@ const CookieConsentBar = dynamic(() => import('./CookieConsentBar'), {
 
 function Layout({ title, description, imageUrl, hasError, children }: PropsWithChildren<Props>) {
     const newsroom = useNewsroom();
+    const story = useCurrentStory();
     const { notifications } = useNewsroomContext();
     const { isEnabled: isAnalyticsEnabled } = useAnalyticsContext();
     const [isLoadingPage, setIsLoadingPage] = useState(false);
-    const { pathname } = useRouter();
+    const { query, pathname } = useRouter();
 
-    const displayedNotifications = useMemo(() => {
-        if (pathname === '/s/[uuid]') {
+    const isSecretUrl = pathname.startsWith('/s/');
+    const isPreviewFlag = Object.keys(query).includes('preview');
+    const isConfidentialStory = story && story.visibility === Story.Visibility.CONFIDENTIAL;
+
+    const isPreview = isSecretUrl && (isPreviewFlag || !isConfidentialStory);
+
+    const displayedNotifications = useMemo((): Notification[] => {
+        if (isPreview) {
             return [
                 ...notifications,
                 {
                     id: 'preview-warning',
                     type: 'preview-warning',
-                    style: 'warning',
+                    style: Notification.Style.WARNING,
                     title: 'This is a preview with a temporary URL which will change after publishing.',
                     description: '',
                     actions: [],
-                } as Notification,
+                },
             ];
         }
 
         return notifications;
-    }, [notifications, pathname]);
+    }, [notifications, isPreview]);
 
     useEffect(() => {
         function onRouteChangeStart() {


### PR DESCRIPTION
Display "This is a preview" banner for confidential stories only if there is `?preview` in the URL