### PR TITLE
[CARE-5022] Feature - Create a mask when preview=true query parameter is present

### DIFF
--- a/components/PreviewPageMask/PreviewPageMask.module.scss
+++ b/components/PreviewPageMask/PreviewPageMask.module.scss
@@ -1,0 +1,6 @@
+.mask {
+    position: fixed;
+    inset: 0;
+    background: transparent;
+    z-index: 9999;
+}

--- a/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/components/PreviewPageMask/PreviewPageMask.tsx
@@ -1,0 +1,14 @@
+import { useSearchParams } from 'next/navigation';
+
+import styles from './PreviewPageMask.module.scss';
+
+export function PreviewPageMask() {
+    const searchParams = useSearchParams();
+    const preview = JSON.parse(searchParams.get('preview') ?? 'false');
+
+    if (!preview) {
+        return null;
+    }
+
+    return <div className={styles.mask} />;
+}

--- a/components/PreviewPageMask/index.ts
+++ b/components/PreviewPageMask/index.ts
@@ -1,0 +1,1 @@
+export { PreviewPageMask } from './PreviewPageMask';

--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -11,6 +11,7 @@ import type { PropsWithChildren } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { NotificationsBar } from '@/components';
+import { PreviewPageMask } from '@/components/PreviewPageMask';
 import { IconArrowTop } from '@/icons';
 import { LoadingBar, ScrollToTopButton } from '@/ui';
 
@@ -106,6 +107,7 @@ function Layout({ title, description, imageUrl, hasError, children }: PropsWithC
                     icon={IconArrowTop}
                     iconClassName={styles.scrollToTopIcon}
                 />
+                <PreviewPageMask />
             </div>
         </>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@prezly/story-content-format": "0.64.0",
         "@prezly/theme-kit-core": "7.4.0",
         "@prezly/theme-kit-intl": "7.4.0",
-        "@prezly/theme-kit-nextjs": "7.4.0",
+        "@prezly/theme-kit-nextjs": "7.4.2",
         "@prezly/uploadcare": "2.4.3",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/@prezly/theme-kit-nextjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-7.4.0.tgz",
-      "integrity": "sha512-1k/0YYQCVysSpdOd9qUcjnzs2HAAdBzGVeKu46SMzKI/ULnpBzbRKNuxKwvPMOYXsepcJvWeOtQG2bBf33Ah4w==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-7.4.2.tgz",
+      "integrity": "sha512-dc6Ur9texb9l9Z7dpmeU88v787iSWxbqiLp+tTc2+TB27AVrn8rZAr9i6pOLVaYp9UnMuZB+RpJyqESxSMywIQ==",
       "dependencies": {
         "@prezly/theme-kit-core": "^7.4.0",
         "@technically/omit-undefined": "^1.0.2",
@@ -19777,9 +19777,9 @@
       }
     },
     "@prezly/theme-kit-nextjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-7.4.0.tgz",
-      "integrity": "sha512-1k/0YYQCVysSpdOd9qUcjnzs2HAAdBzGVeKu46SMzKI/ULnpBzbRKNuxKwvPMOYXsepcJvWeOtQG2bBf33Ah4w==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-7.4.2.tgz",
+      "integrity": "sha512-dc6Ur9texb9l9Z7dpmeU88v787iSWxbqiLp+tTc2+TB27AVrn8rZAr9i6pOLVaYp9UnMuZB+RpJyqESxSMywIQ==",
       "requires": {
         "@prezly/theme-kit-core": "^7.4.0",
         "@technically/omit-undefined": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@prezly/story-content-format": "0.64.0",
     "@prezly/theme-kit-core": "7.4.0",
     "@prezly/theme-kit-intl": "7.4.0",
-    "@prezly/theme-kit-nextjs": "7.4.0",
+    "@prezly/theme-kit-nextjs": "7.4.2",
     "@prezly/uploadcare": "2.4.3",
     "@prezly/uploadcare-image": "0.3.2",
     "@react-hookz/web": "14.7.1",


### PR DESCRIPTION
Implemented a component that creates a fixed overlay covering the entire page, preventing the user from clicking anything, but still allow scrolling.

This functionality only works when `preview=true` query parameter is present and is intended to work with our live theme preview functionality.

Also includes updated theme kit with the updated CSP header.