### PR TITLE
[CARE-5040] Fix - Correctly handle preview query param

### DIFF
--- a/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/components/PreviewPageMask/PreviewPageMask.tsx
@@ -4,7 +4,7 @@ import styles from './PreviewPageMask.module.scss';
 
 export function PreviewPageMask() {
     const searchParams = useSearchParams();
-    const preview = JSON.parse(searchParams.get('preview') ?? 'false');
+    const preview = JSON.parse(searchParams.get('preview') || 'false');
 
     if (!preview) {
         return null;

--- a/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/components/PreviewPageMask/PreviewPageMask.tsx
@@ -4,9 +4,9 @@ import styles from './PreviewPageMask.module.scss';
 
 export function PreviewPageMask() {
     const searchParams = useSearchParams();
-    const preview = JSON.parse(searchParams.get('preview') || 'false');
+    const mask = JSON.parse(searchParams.get('mask') || 'false');
 
-    if (!preview) {
+    if (!mask) {
         return null;
     }
 


### PR DESCRIPTION
I haven't realised we use `preview` parameter when previewing stories, so `JSON.parse` wasn't able to parse it and the fallback was only applied if the query parameter does not exist.

I've changed the parameter's name to `mask`, so it does not clash.